### PR TITLE
Fix: Declaration of dcb9\redis\Connection::flushDB() should be compatible with Redis::flushDB($async = NULL)

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -123,8 +123,8 @@ class Connection extends Redis implements Configurable
         return parent::ping() === '+PONG';
     }
 
-    public function flushdb()
+    public function flushDB($async = null)
     {
-        return parent::flushDB();
+        return parent::flushDB($async);
     }
 }


### PR DESCRIPTION
This error popped while working on Admin Tools. It needs to be fixed before moving forward and use this package in all our repos.

