### PR TITLE
Implement Redis execute retry mechanism with raw command

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -200,7 +200,6 @@ class Connection extends Redis implements Configurable
                 // In case Redis is not accessible, close the connection, wait for the retry interval.
                 $this->close();
                 if ($this->retryInterval > 0) {
-                    //echo 'retry interval <br/>';
                     usleep($this->retryInterval);
                 }
             }

--- a/Connection.php
+++ b/Connection.php
@@ -111,7 +111,7 @@ class Connection extends Redis implements Configurable
         if (in_array($command, array_keys($this->redisRetryCommands))) {
             if ($command === 'retryMulti') {
                 $this->multiExecCommand = true;
-                $this->multiCommands[]  = [];
+                $this->multiCommands    = [];
                 $this->multiCommands[]  = $this->computeRawCommand($command, $params);
                 return $this;
             }
@@ -124,7 +124,7 @@ class Connection extends Redis implements Configurable
                 $this->multiCommands[]  = $this->computeRawCommand($command, $params);
                 $this->multiExecCommand = false;
                 $responseMultiCommand   = $this->executeMultiCommand($this->multiCommands);
-                $this->multiCommands[]  = [];
+                $this->multiCommands    = [];
                 return $responseMultiCommand;
             }
             if ($this->multiExecCommand === false) {

--- a/Connection.php
+++ b/Connection.php
@@ -200,7 +200,7 @@ class Connection extends Redis implements Configurable
                 // In case Redis is not accessible, close the connection, wait for the retry interval.
                 $this->close();
                 if ($this->retryInterval > 0) {
-                    usleep($this->retryInterval);
+                    usleep($this->retryInterval * 1000);
                 }
             }
         }
@@ -256,7 +256,7 @@ class Connection extends Redis implements Configurable
                 // In case Redis is not accessible, close the connection, wait for the retry interval.
                 $this->close();
                 if ($this->retryInterval > 0) {
-                    usleep($this->retryInterval);
+                    usleep($this->retryInterval * 1000);
                 }
             }
         }


### PR DESCRIPTION
Implement in Yii2 PHP Redis an easy way to execute Redis commands with retries. 

There are 2 types of redis commands which are executed:
1. Multi / exec command which chain the redis actions - required for API Cache system
2. Run single command on redis 

The retry mechanism will try to run the command and in case it fails, it will retry at `retries` number of times at `retryInterval` time. In case these are 0, then the command will be run only once.
In case the redis command fails, it will catch the error, try to reopen the Redis connection and re-run the same command. 
In case there is 1 single command run without retry then an Exception is thrown in case Redis is not accessible. 