### PR TITLE
feat: change signature for new phpredis versions

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -205,9 +205,9 @@ class Connection extends Redis implements Configurable
         return parent::ping() === '+PONG';
     }
 
-    public function flushDB($async = null)
+    public function flushDB(?bool $sync = null): \Redis|bool
     {
-        return parent::flushDB($async);
+        return parent::flushDB($sync);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "yiisoft/yii2": "~2.0.4",
+    "yiisoft/yii2": "^2.0.4",
     "ext-redis": ">=2.2.7",
     "php": ">=5.4.0"
   },


### PR DESCRIPTION
https://linear.app/float-com/issue/PS-1844/upgrade-php-version-for-float-admin-tools-from-83-to-84

This is required 
 - To support moving to redis-6.3.0 in [yii-php-api-cache-component](https://github.com/floatschedule/yii-php-api-cache-component) [PR](https://github.com/floatschedule/yii-php-api-cache-component/pull/82/changes)
 - To support moving from PHP 8.3 to 8.4 (the image contains a redis upgrade) in [float admin tools](https://github.com/floatschedule/float-admin-tools/pull/232/changes), api3 and float2