### PR TITLE
PS-1844: make remaining changes for phpredis 6.x

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -166,20 +166,16 @@ class Connection extends Redis implements Configurable
      * @param int       $retry_interval
      * @return bool
      */
-    public function open( $host = null, $port = null, $timeout = null, $retry_interval = 0 )
+    public function open(string $host = 'localhost', int $port = 6379, float $timeout = 0, ?string $persistent_id = null, int $retry_interval = 0, float $read_timeout = 0, ?array $context = null): bool
     {
         if ($this->unixSocket !== null) {
             $isConnected = $this->connect($this->unixSocket);
         } else {
-            if(is_null($host)){
-                $host = $this->hostname;
-            }
-            if(is_null($port)){
-                $port = $this->port;
-            }
-            if(is_null($timeout)){
-                $timeout = $this->connectionTimeout;
-            }
+            // Use class properties if set, otherwise fall back to parameter defaults.
+            // This preserves original behavior where Yii2 config takes precedence.
+            $host = $this->hostname ?: $host;
+            $port = $this->port ?: $port;
+            $timeout = $this->connectionTimeout ?: $timeout;
             
             $isConnected = $this->connect($host, $port, $timeout, null, $retry_interval, $this->readTimeout);
         }
@@ -195,14 +191,16 @@ class Connection extends Redis implements Configurable
         if ($this->database !== null) {
             $this->select($this->database);
         }
+
+        return true;
     }
 
     /**
      * @return bool
      */
-    public function ping()
+    public function ping(?string $message = null): \Redis|string|bool
     {
-        return parent::ping() === '+PONG';
+        return parent::ping($message) === '+PONG';
     }
 
     public function flushDB(?bool $sync = null): \Redis|bool


### PR DESCRIPTION
https://linear.app/float-com/issue/PS-1844/upgrade-php-version-for-float-admin-tools-from-83-to-84

This is required 
 - To support moving to redis-6.3.0 in [yii-php-api-cache-component](https://github.com/floatschedule/yii-php-api-cache-component) [PR](https://github.com/floatschedule/yii-php-api-cache-component/pull/82/changes)
 - To support moving from PHP 8.3 to 8.4 (the image contains a redis upgrade) in [float admin tools](https://github.com/floatschedule/float-admin-tools/pull/232/changes), api3 and float2

Note, this will go out as a new release and will only be available to services on upgrading version – I'm going to mark it as a major version as it's a breaking change

Testing notes:

You can see that in the upstream package that requires this update that the tests are now passing, when I apply a patch with the changes found in this PR (I tested with a patch as it was easier to confirm the changes worked than publishing this package again and again) https://github.com/floatschedule/yii-php-api-cache-component/pull/82/changes#diff-9a1585b743fb1e0cf62c37b3f862c6f9750d7022e6ecbd248bb514c404e3b5d2

Previously I made a change in this package https://github.com/floatschedule/yii2-phpredis/pull/5 only to find out that there were two more needed that were not surfaced in the tests 😢 

